### PR TITLE
fix: buildが通るように調整

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,9 @@ install(TARGETS
   pcl_functions
   DESTINATION lib/${PROJECT_NAME})
 
-# configディレクトリとlaunchディレクトリのインストール
-install(DIRECTORY config
+# launchディレクトリのインストール
+install(DIRECTORY 
+  launch
   DESTINATION share/${PROJECT_NAME}/
 )
 

--- a/src/obstacle_cloud_to_scan.cpp
+++ b/src/obstacle_cloud_to_scan.cpp
@@ -9,7 +9,6 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_sensor_msgs/tf2_sensor_msgs.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <pointcloud_to_laserscan/pointcloud_to_laserscan_node.hpp>
 #include "obstacle_cloud_to_scan/pcl_functions.hpp"
 
 #include <pcl/common/transforms.h>


### PR DESCRIPTION
興味本位で動かそうとしたらbuildが通らなかったので、通るように変更しました
変更点は
- CMakeで記述されているconfigフォルダが存在しないのでその記述の削除
- obstacle_cloud_to_scan.cppに記述されているpointcloud_to_laserscan/pointcloud_to_laserscan_node.hppのヘッダーファイルも同様に存在しないので、その記述を削除

以上です🙏